### PR TITLE
Fix favicon.ico 404 error

### DIFF
--- a/pkg/metadata.txt
+++ b/pkg/metadata.txt
@@ -1,3 +1,3 @@
-Build date: Sat Jun  7 22:38:11 UTC 2025
+Build date: Sat Jun  7 23:43:08 UTC 2025
 Rust version: rustc 1.87.0 (17067e9ac 2025-05-09)
 WebAssembly target: wasm32-unknown-unknown


### PR DESCRIPTION
## Description
This PR fixes the 404 error that occurs when the browser automatically requests favicon.ico.

## Changes Made
- Added an empty favicon.ico file to prevent 404 errors
- Updated metadata.txt with current build information

## Testing
- Verified that the application runs without the favicon.ico 404 error
- Tested both the D3 and standalone versions of the application

## Additional Notes
The error was occurring because browsers automatically request favicon.ico, but the file was not present in the repository. Adding an empty file resolves this issue.