### PR TITLE
Add NEX publisher for simulated data

### DIFF
--- a/start-nats.sh
+++ b/start-nats.sh
@@ -5,17 +5,35 @@ echo "Starting local NATS server..."
 
 # Check if Docker is installed
 if ! command -v docker &> /dev/null; then
-    echo "Docker is not installed. Please install Docker to run the local NATS server."
-    exit 1
-fi
-
-# Check if the NATS container is already running
-if docker ps | grep -q nats-server; then
-    echo "NATS server is already running."
+    echo "Docker is not installed. Checking for local NATS server..."
+    
+    # Check if nats-server is installed
+    if command -v nats-server &> /dev/null; then
+        echo "Found local nats-server. Starting..."
+        nats-server -p 4222 -m 8222 &
+        echo "NATS server started on port 4222."
+    else
+        echo "Neither Docker nor nats-server is installed."
+        echo "Will use the demo NATS server at nats://demo.nats.io:4222 instead."
+        export NEX_URL="nats://demo.nats.io:4222"
+        return 0
+    fi
 else
-    # Start the NATS server
-    docker run -d --name nats-server -p 4222:4222 -p 8222:8222 nats:latest
-    echo "NATS server started on port 4222."
+    # Check if the NATS container is already running
+    if docker ps | grep -q nats-server; then
+        echo "NATS server container is already running."
+    else
+        # Check if the container exists but is stopped
+        if docker ps -a | grep -q nats-server; then
+            echo "Starting existing NATS server container..."
+            docker start nats-server
+        else
+            # Start a new NATS server container
+            echo "Creating and starting new NATS server container..."
+            docker run -d --name nats-server -p 4222:4222 -p 8222:8222 nats:latest
+        fi
+        echo "NATS server started on port 4222."
+    fi
 fi
 
 # Print the NATS server URL

--- a/start.sh
+++ b/start.sh
@@ -19,7 +19,11 @@ echo "Building main application..."
 # Build the NEX publisher
 echo "Building NEX publisher..."
 cd nex-publisher
-cargo build --release
+if ! cargo build --release; then
+  echo "Failed to build NEX publisher. Will use simulation mode instead."
+  USE_SIMULATION="true"
+  USE_LOCAL_NATS="false"
+fi
 cd ..
 
 # Build the unified Rust server
@@ -31,7 +35,10 @@ cd ..
 # Start the local NATS server if needed
 if [ "$USE_LOCAL_NATS" = "true" ]; then
   echo "Starting local NATS server..."
-  ./start-nats.sh
+  if ! ./start-nats.sh; then
+    echo "Failed to start local NATS server. Will use demo NATS server instead."
+    NEX_URL="nats://demo.nats.io:4222"
+  fi
 fi
 
 # Start the NEX publisher if using local NATS


### PR DESCRIPTION
## Description
This PR adds a NEX publisher application that generates simulated BTC-USD trade data and publishes it to a NATS server. It also updates the startup scripts to use this local NEX publisher by default, making it easier to test the NEX Stream integration without needing an external NATS server.

## Changes Made
- Added a new Rust application (nex-publisher) that connects to a NATS server and publishes simulated BTC-USD trade data
- Added scripts for starting the NATS server, NEX publisher, and server components separately
- Updated the main start.sh script to use the local NEX publisher by default
- Added robust error handling for connection failures and startup issues
- Updated the README with detailed documentation about the NEX publisher and its options

## Benefits
- Makes it easier to test the NEX Stream integration without needing an external NATS server
- Provides a more realistic testing environment with actual NATS messages
- Allows for customization of the simulated data (interval, volatility, etc.)
- Improves reliability with better error handling and fallback options

## Testing
- Tested the NEX publisher with a local NATS server
- Verified that the server can connect to the local NATS server and receive messages
- Tested the fallback to simulation mode when the NATS server is not available